### PR TITLE
fix(Cache): cache renameSync delete throws exception sometimes AB#6486

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -3328,6 +3328,7 @@ class LockCachingAudioSource extends StreamAudioSource {
   final _requests = <_StreamingByteRangeRequest>[];
   final _downloadProgressSubject = BehaviorSubject<double>();
   bool _downloading = false;
+  Completer<void>? _downloadCompleter;
 
   /// Creates a [LockCachingAudioSource] to that provides [uri] to the player
   /// while simultaneously caching it to [cacheFile]. If no cache file is
@@ -3368,10 +3369,20 @@ class LockCachingAudioSource extends StreamAudioSource {
     if (_downloading) {
       throw Exception("Cannot clear cache while download is in progress");
     }
+
+    // Wait for any pending download completion to finish
+    if (_downloadCompleter != null && !_downloadCompleter!.isCompleted) {
+      await _downloadCompleter!.future;
+    }
+
     _response = null;
     final cacheFile = await this.cacheFile;
     if (await cacheFile.exists()) {
       await cacheFile.delete();
+    }
+    final partialCacheFile = await _partialCacheFile;
+    if (await partialCacheFile.exists()) {
+      await partialCacheFile.delete();
     }
     final mimeFile = await _mimeFile;
     if (await mimeFile.exists()) {
@@ -3420,6 +3431,7 @@ class LockCachingAudioSource extends StreamAudioSource {
   /// entire file continues in parallel.
   Future<HttpClientResponse> _fetch() async {
     _downloading = true;
+    _downloadCompleter = Completer<void>();
     final cacheFile = await this.cacheFile;
     final partialCacheFile = await _partialCacheFile;
 
@@ -3568,32 +3580,63 @@ class LockCachingAudioSource extends StreamAudioSource {
         });
       }
     }, onDone: () async {
-      if (sourceLength == null) {
-        updateProgress(100);
-      }
-      for (var cacheResponse in inProgressResponses) {
-        if (!cacheResponse.controller.isClosed) {
-          cacheResponse.controller.close();
+      try {
+        if (sourceLength == null) {
+          updateProgress(100);
+        }
+        for (var cacheResponse in inProgressResponses) {
+          if (!cacheResponse.controller.isClosed) {
+            cacheResponse.controller.close();
+          }
+        }
+
+        // Safely rename the partial cache file to the final cache file
+        final partialFile = await _partialCacheFile;
+        if (partialFile.existsSync()) {
+          try {
+            partialFile.renameSync(cacheFile.path);
+          } catch (e) {
+            // If rename fails (e.g., due to race condition with clearCache),
+            // just delete the partial file to clean up
+            if (partialFile.existsSync()) {
+              partialFile.deleteSync();
+            }
+          }
+        }
+
+        await subscription.cancel();
+        httpClient.close();
+        _downloading = false;
+      } finally {
+        // Always complete the download completer to unblock any waiting clearCache calls
+        if (_downloadCompleter != null && !_downloadCompleter!.isCompleted) {
+          _downloadCompleter!.complete();
         }
       }
-      (await _partialCacheFile).renameSync(cacheFile.path);
-      await subscription.cancel();
-      httpClient.close();
-      _downloading = false;
     }, onError: (Object e, StackTrace stackTrace) async {
-      (await _partialCacheFile).deleteSync();
-      httpClient.close();
-      // Fail all pending requests
-      for (final req in _requests) {
-        req.fail(e, stackTrace);
+      try {
+        final partialFile = await _partialCacheFile;
+        if (partialFile.existsSync()) {
+          partialFile.deleteSync();
+        }
+        httpClient.close();
+        // Fail all pending requests
+        for (final req in _requests) {
+          req.fail(e, stackTrace);
+        }
+        _requests.clear();
+        // Close all in progress requests
+        for (final res in inProgressResponses) {
+          res.controller.addError(e, stackTrace);
+          res.controller.close();
+        }
+        _downloading = false;
+      } finally {
+        // Always complete the download completer to unblock any waiting clearCache calls
+        if (_downloadCompleter != null && !_downloadCompleter!.isCompleted) {
+          _downloadCompleter!.complete();
+        }
       }
-      _requests.clear();
-      // Close all in progress requests
-      for (final res in inProgressResponses) {
-        res.controller.addError(e, stackTrace);
-        res.controller.close();
-      }
-      _downloading = false;
     }, cancelOnError: true);
     return response;
   }


### PR DESCRIPTION
[AB#6486](https://dev.azure.com/neonscreens/b9d23205-2576-4eec-b4ed-9127168fa8ad/_workitems/edit/6486)

```console
The following PathNotFoundException was thrown running a test (but after the test had completed):
Cannot rename file to
'/data/user/0/com.neonmusic.app.dev/cache/just_audio_cache/remote/5bbbb73c87a5ee3165bddfd2f2685dd9603054757386b53adabee8952cebb6cb.mp3',
path =
'/data/user/0/com.neonmusic.app.dev/cache/just_audio_cache/remote/5bbbb73c87a5ee3165bddfd2f2685dd9603054757386b53adabee8952cebb6cb.mp3.part'
(OS Error: No such file or directory, errno = 2)

When the exception was thrown, this was the stack:
#0      _File.throwIfError (dart:io/file_impl.dart:782:7)
#1      _File.renameSync (dart:io/file_impl.dart:399:5)
#2      LockCachingAudioSource._fetch.<anonymous closure> (package:just_audio/just_audio.dart:3578:33)
<asynchronous suspension>
```

Original PR:
- https://github.com/ryanheise/just_audio/pull/1492