### PR TITLE
fix(ConcatenatingAudioSource): rollback Dart children on platform channel failure

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2998,12 +2998,19 @@ class ConcatenatingAudioSource extends AudioSource {
         if (player._active) {
           await audioSource._onLoad();
         }
-        await (await player._platform).concatenatingInsertAll(
-            ConcatenatingInsertAllRequest(
-                id: _id,
-                index: index,
-                children: [audioSource._toMessage()],
-                shuffleOrder: List.of(_shuffleOrder.indices)));
+        try {
+          await (await player._platform).concatenatingInsertAll(
+              ConcatenatingInsertAllRequest(
+                  id: _id,
+                  index: index,
+                  children: [audioSource._toMessage()],
+                  shuffleOrder: List.of(_shuffleOrder.indices)));
+        } catch (e) {
+          children.removeAt(index);
+          _shuffleOrder.removeRange(index, index + 1);
+          await player._broadcastSequence();
+          rethrow;
+        }
       }
     });
   }
@@ -3020,12 +3027,19 @@ class ConcatenatingAudioSource extends AudioSource {
         if (player._active) {
           await audioSource._onLoad();
         }
-        await (await player._platform).concatenatingInsertAll(
-            ConcatenatingInsertAllRequest(
-                id: _id,
-                index: index,
-                children: [audioSource._toMessage()],
-                shuffleOrder: List.of(_shuffleOrder.indices)));
+        try {
+          await (await player._platform).concatenatingInsertAll(
+              ConcatenatingInsertAllRequest(
+                  id: _id,
+                  index: index,
+                  children: [audioSource._toMessage()],
+                  shuffleOrder: List.of(_shuffleOrder.indices)));
+        } catch (e) {
+          children.removeAt(index);
+          _shuffleOrder.removeRange(index, index + 1);
+          await player._broadcastSequence();
+          rethrow;
+        }
       }
     });
   }
@@ -3047,12 +3061,20 @@ class ConcatenatingAudioSource extends AudioSource {
             await child._onLoad();
           }
         }
-        await (await player._platform).concatenatingInsertAll(
-            ConcatenatingInsertAllRequest(
-                id: _id,
-                index: index,
-                children: children.map((child) => child._toMessage()).toList(),
-                shuffleOrder: List.of(_shuffleOrder.indices)));
+        try {
+          await (await player._platform).concatenatingInsertAll(
+              ConcatenatingInsertAllRequest(
+                  id: _id,
+                  index: index,
+                  children:
+                      children.map((child) => child._toMessage()).toList(),
+                  shuffleOrder: List.of(_shuffleOrder.indices)));
+        } catch (e) {
+          this.children.removeRange(index, index + children.length);
+          _shuffleOrder.removeRange(index, index + children.length);
+          await player._broadcastSequence();
+          rethrow;
+        }
       }
     });
   }
@@ -3073,12 +3095,20 @@ class ConcatenatingAudioSource extends AudioSource {
             await child._onLoad();
           }
         }
-        await (await player._platform).concatenatingInsertAll(
-            ConcatenatingInsertAllRequest(
-                id: _id,
-                index: index,
-                children: children.map((child) => child._toMessage()).toList(),
-                shuffleOrder: List.of(_shuffleOrder.indices)));
+        try {
+          await (await player._platform).concatenatingInsertAll(
+              ConcatenatingInsertAllRequest(
+                  id: _id,
+                  index: index,
+                  children:
+                      children.map((child) => child._toMessage()).toList(),
+                  shuffleOrder: List.of(_shuffleOrder.indices)));
+        } catch (e) {
+          this.children.removeRange(index, index + children.length);
+          _shuffleOrder.removeRange(index, index + children.length);
+          await player._broadcastSequence();
+          rethrow;
+        }
       }
     });
   }
@@ -3087,17 +3117,24 @@ class ConcatenatingAudioSource extends AudioSource {
   /// [ConcatenatingAudioSource] has already been loaded.
   Future<void> removeAt(int index) {
     return _lock.synchronized(() async {
-      children.removeAt(index);
+      final removedChild = children.removeAt(index);
       _shuffleOrder.removeRange(index, index + 1);
       final player = _player;
       if (player != null) {
         await player._broadcastSequence();
-        await (await player._platform).concatenatingRemoveRange(
-            ConcatenatingRemoveRangeRequest(
-                id: _id,
-                startIndex: index,
-                endIndex: index + 1,
-                shuffleOrder: List.of(_shuffleOrder.indices)));
+        try {
+          await (await player._platform).concatenatingRemoveRange(
+              ConcatenatingRemoveRangeRequest(
+                  id: _id,
+                  startIndex: index,
+                  endIndex: index + 1,
+                  shuffleOrder: List.of(_shuffleOrder.indices)));
+        } catch (e) {
+          children.insert(index, removedChild);
+          _shuffleOrder.insert(index, 1);
+          await player._broadcastSequence();
+          rethrow;
+        }
       }
     });
   }
@@ -3106,17 +3143,25 @@ class ConcatenatingAudioSource extends AudioSource {
   /// exclusive.
   Future<void> removeRange(int start, int end) {
     return _lock.synchronized(() async {
+      final removedChildren = children.sublist(start, end);
       children.removeRange(start, end);
       _shuffleOrder.removeRange(start, end);
       final player = _player;
       if (player != null) {
         await player._broadcastSequence();
-        await (await player._platform).concatenatingRemoveRange(
-            ConcatenatingRemoveRangeRequest(
-                id: _id,
-                startIndex: start,
-                endIndex: end,
-                shuffleOrder: List.of(_shuffleOrder.indices)));
+        try {
+          await (await player._platform).concatenatingRemoveRange(
+              ConcatenatingRemoveRangeRequest(
+                  id: _id,
+                  startIndex: start,
+                  endIndex: end,
+                  shuffleOrder: List.of(_shuffleOrder.indices)));
+        } catch (e) {
+          children.insertAll(start, removedChildren);
+          _shuffleOrder.insert(start, removedChildren.length);
+          await player._broadcastSequence();
+          rethrow;
+        }
       }
     });
   }
@@ -3130,12 +3175,21 @@ class ConcatenatingAudioSource extends AudioSource {
       final player = _player;
       if (player != null) {
         await player._broadcastSequence();
-        await (await player._platform).concatenatingMove(
-            ConcatenatingMoveRequest(
-                id: _id,
-                currentIndex: currentIndex,
-                newIndex: newIndex,
-                shuffleOrder: List.of(_shuffleOrder.indices)));
+        try {
+          await (await player._platform).concatenatingMove(
+              ConcatenatingMoveRequest(
+                  id: _id,
+                  currentIndex: currentIndex,
+                  newIndex: newIndex,
+                  shuffleOrder: List.of(_shuffleOrder.indices)));
+        } catch (e) {
+          // Reverse the move
+          children.insert(currentIndex, children.removeAt(newIndex));
+          _shuffleOrder.removeRange(newIndex, newIndex + 1);
+          _shuffleOrder.insert(currentIndex, 1);
+          await player._broadcastSequence();
+          rethrow;
+        }
       }
     });
   }

--- a/just_audio/test/just_audio_test.dart
+++ b/just_audio/test/just_audio_test.dart
@@ -1716,6 +1716,211 @@ void runTests() {
     expect(player.shuffleModeEnabled, equals(true));
     await player.dispose();
   });
+
+  group('rollback on platform failure', () {
+    late FailingMockJustAudio failingMock;
+
+    setUp(() {
+      failingMock = FailingMockJustAudio();
+      JustAudioPlatform.instance = failingMock;
+    });
+
+    tearDown(() {
+      JustAudioPlatform.instance = MockJustAudio();
+    });
+
+    test('insert rolls back children on platform failure', () async {
+      final player = AudioPlayer();
+      final source = ConcatenatingAudioSource(children: [
+        AudioSource.uri(Uri.parse('https://a.a/a.mp3'), tag: 'a'),
+        AudioSource.uri(Uri.parse('https://b.b/b.mp3'), tag: 'b'),
+      ]);
+      await player.setAudioSource(source);
+      failingMock.mostRecentPlayer!.failConcatenatingInsert = true;
+
+      final childrenBefore =
+          source.sequence.map((s) => s.tag as String?).toList();
+
+      Object? error;
+      try {
+        await source.insert(
+            1, AudioSource.uri(Uri.parse('https://c.c/c.mp3'), tag: 'c'));
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error, isA<PlatformException>());
+      final result = source.sequence.map((s) => s.tag as String?).toList();
+      expect(result, equals(childrenBefore));
+      expect(source.length, equals(2));
+      await player.dispose();
+    });
+
+    test('add rolls back children on platform failure', () async {
+      final player = AudioPlayer();
+      final source = ConcatenatingAudioSource(children: [
+        AudioSource.uri(Uri.parse('https://a.a/a.mp3'), tag: 'a'),
+      ]);
+      await player.setAudioSource(source);
+      failingMock.mostRecentPlayer!.failConcatenatingInsert = true;
+
+      Object? error;
+      try {
+        await source
+            .add(AudioSource.uri(Uri.parse('https://b.b/b.mp3'), tag: 'b'));
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error, isA<PlatformException>());
+      final result = source.sequence.map((s) => s.tag as String?).toList();
+      expect(result, equals(['a']));
+      expect(source.length, equals(1));
+      await player.dispose();
+    });
+
+    test('addAll rolls back children on platform failure', () async {
+      final player = AudioPlayer();
+      final source = ConcatenatingAudioSource(children: [
+        AudioSource.uri(Uri.parse('https://a.a/a.mp3'), tag: 'a'),
+      ]);
+      await player.setAudioSource(source);
+      failingMock.mostRecentPlayer!.failConcatenatingInsert = true;
+
+      Object? error;
+      try {
+        await source.addAll([
+          AudioSource.uri(Uri.parse('https://b.b/b.mp3'), tag: 'b'),
+          AudioSource.uri(Uri.parse('https://c.c/c.mp3'), tag: 'c'),
+        ]);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error, isA<PlatformException>());
+      final result = source.sequence.map((s) => s.tag as String?).toList();
+      expect(result, equals(['a']));
+      expect(source.length, equals(1));
+      await player.dispose();
+    });
+
+    test('insertAll rolls back children on platform failure', () async {
+      final player = AudioPlayer();
+      final source = ConcatenatingAudioSource(children: [
+        AudioSource.uri(Uri.parse('https://a.a/a.mp3'), tag: 'a'),
+        AudioSource.uri(Uri.parse('https://d.d/d.mp3'), tag: 'd'),
+      ]);
+      await player.setAudioSource(source);
+      failingMock.mostRecentPlayer!.failConcatenatingInsert = true;
+
+      Object? error;
+      try {
+        await source.insertAll(1, [
+          AudioSource.uri(Uri.parse('https://b.b/b.mp3'), tag: 'b'),
+          AudioSource.uri(Uri.parse('https://c.c/c.mp3'), tag: 'c'),
+        ]);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error, isA<PlatformException>());
+      final result = source.sequence.map((s) => s.tag as String?).toList();
+      expect(result, equals(['a', 'd']));
+      expect(source.length, equals(2));
+      await player.dispose();
+    });
+
+    test('removeAt rolls back children on platform failure', () async {
+      final player = AudioPlayer();
+      final source = ConcatenatingAudioSource(children: [
+        AudioSource.uri(Uri.parse('https://a.a/a.mp3'), tag: 'a'),
+        AudioSource.uri(Uri.parse('https://b.b/b.mp3'), tag: 'b'),
+        AudioSource.uri(Uri.parse('https://c.c/c.mp3'), tag: 'c'),
+      ]);
+      await player.setAudioSource(source);
+      failingMock.mostRecentPlayer!.failConcatenatingRemove = true;
+
+      Object? error;
+      try {
+        await source.removeAt(1);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error, isA<PlatformException>());
+      final result = source.sequence.map((s) => s.tag as String?).toList();
+      expect(result, equals(['a', 'b', 'c']));
+      expect(source.length, equals(3));
+      await player.dispose();
+    });
+
+    test('removeRange rolls back children on platform failure', () async {
+      final player = AudioPlayer();
+      final source = ConcatenatingAudioSource(children: [
+        AudioSource.uri(Uri.parse('https://a.a/a.mp3'), tag: 'a'),
+        AudioSource.uri(Uri.parse('https://b.b/b.mp3'), tag: 'b'),
+        AudioSource.uri(Uri.parse('https://c.c/c.mp3'), tag: 'c'),
+        AudioSource.uri(Uri.parse('https://d.d/d.mp3'), tag: 'd'),
+      ]);
+      await player.setAudioSource(source);
+      failingMock.mostRecentPlayer!.failConcatenatingRemove = true;
+
+      Object? error;
+      try {
+        await source.removeRange(1, 3);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error, isA<PlatformException>());
+      final result = source.sequence.map((s) => s.tag as String?).toList();
+      expect(result, equals(['a', 'b', 'c', 'd']));
+      expect(source.length, equals(4));
+      await player.dispose();
+    });
+
+    test('move rolls back children on platform failure', () async {
+      final player = AudioPlayer();
+      final source = ConcatenatingAudioSource(children: [
+        AudioSource.uri(Uri.parse('https://a.a/a.mp3'), tag: 'a'),
+        AudioSource.uri(Uri.parse('https://b.b/b.mp3'), tag: 'b'),
+        AudioSource.uri(Uri.parse('https://c.c/c.mp3'), tag: 'c'),
+      ]);
+      await player.setAudioSource(source);
+      failingMock.mostRecentPlayer!.failConcatenatingMove = true;
+
+      Object? error;
+      try {
+        await source.move(0, 2);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error, isA<PlatformException>());
+      final result = source.sequence.map((s) => s.tag as String?).toList();
+      expect(result, equals(['a', 'b', 'c']));
+      expect(source.length, equals(3));
+      await player.dispose();
+    });
+
+    test('operations work normally when platform does not fail', () async {
+      final player = AudioPlayer();
+      final source = ConcatenatingAudioSource(children: [
+        AudioSource.uri(Uri.parse('https://a.a/a.mp3'), tag: 'a'),
+      ]);
+      await player.setAudioSource(source);
+
+      await source.insert(
+          1, AudioSource.uri(Uri.parse('https://b.b/b.mp3'), tag: 'b'));
+      await source
+          .add(AudioSource.uri(Uri.parse('https://c.c/c.mp3'), tag: 'c'));
+
+      final result = source.sequence.map((s) => s.tag as String?).toList();
+      expect(result, equals(['a', 'b', 'c']));
+      expect(source.length, equals(3));
+      await player.dispose();
+    });
+  });
 }
 
 class MockJustAudio extends Mock
@@ -2203,3 +2408,85 @@ class MockWebServer {
 class MyHttpOverrides extends HttpOverrides {}
 
 T? _ambiguate<T>(T? value) => value;
+
+class FailingMockJustAudio extends Mock
+    with MockPlatformInterfaceMixin
+    implements JustAudioPlatform {
+  FailingMockAudioPlayer? mostRecentPlayer;
+  final _players = <String, FailingMockAudioPlayer>{};
+
+  @override
+  Future<AudioPlayerPlatform> init(InitRequest request) async {
+    if (_players.containsKey(request.id)) {
+      throw PlatformException(
+          code: "error",
+          message: "Platform player ${request.id} already exists");
+    }
+    final player = FailingMockAudioPlayer(request);
+    _players[request.id] = player;
+    mostRecentPlayer = player;
+    return player;
+  }
+
+  @override
+  Future<DisposePlayerResponse> disposePlayer(
+      DisposePlayerRequest request) async {
+    _players[request.id]!.dispose(DisposeRequest());
+    _players.remove(request.id);
+    return DisposePlayerResponse();
+  }
+
+  @override
+  Future<DisposeAllPlayersResponse> disposeAllPlayers(
+      DisposeAllPlayersRequest request) async {
+    for (var player in _players.values) {
+      player.dispose(DisposeRequest());
+    }
+    _players.clear();
+    return DisposeAllPlayersResponse();
+  }
+}
+
+class FailingMockAudioPlayer extends MockAudioPlayer {
+  bool failConcatenatingInsert = false;
+  bool failConcatenatingRemove = false;
+  bool failConcatenatingMove = false;
+
+  FailingMockAudioPlayer(InitRequest request) : super(request);
+
+  @override
+  Future<ConcatenatingInsertAllResponse> concatenatingInsertAll(
+      ConcatenatingInsertAllRequest request) async {
+    if (failConcatenatingInsert) {
+      throw PlatformException(
+        code: 'Error: java.lang.IllegalArgumentException',
+        message: 'java.lang.IllegalArgumentException',
+      );
+    }
+    return super.concatenatingInsertAll(request);
+  }
+
+  @override
+  Future<ConcatenatingRemoveRangeResponse> concatenatingRemoveRange(
+      ConcatenatingRemoveRangeRequest request) async {
+    if (failConcatenatingRemove) {
+      throw PlatformException(
+        code: 'Error: java.lang.IllegalArgumentException',
+        message: 'java.lang.IllegalArgumentException',
+      );
+    }
+    return super.concatenatingRemoveRange(request);
+  }
+
+  @override
+  Future<ConcatenatingMoveResponse> concatenatingMove(
+      ConcatenatingMoveRequest request) async {
+    if (failConcatenatingMove) {
+      throw PlatformException(
+        code: 'Error: java.lang.IllegalArgumentException',
+        message: 'java.lang.IllegalArgumentException',
+      );
+    }
+    return super.concatenatingMove(request);
+  }
+}


### PR DESCRIPTION
## Summary
- When `ConcatenatingAudioSource` mutation methods (`insert`, `add`, `addAll`, `insertAll`, `removeAt`, `removeRange`, `move`) send a platform channel call that fails (e.g. `IllegalArgumentException` from ExoPlayer when index > native media count), the Dart-side `children` list and `_shuffleOrder` were already mutated with **no rollback**
- This caused permanent Dart-native state desync: Dart had N±1 items while native had N, making all subsequent operations send wrong indices and causing cascading `IllegalArgumentException` failures
- Wraps all platform channel calls in try/catch blocks that restore `children` and `_shuffleOrder` to their pre-mutation state on failure, then rethrow

## Test plan
- [x] 8 new unit tests covering rollback for each mutation method (`insert`, `add`, `addAll`, `insertAll`, `removeAt`, `removeRange`, `move`) plus a positive control test
- [x] Uses `FailingMockAudioPlayer` that throws `PlatformException` to simulate native failures
- [x] Each test verifies children list and length are restored to pre-mutation state after failure
- [x] All 62 tests pass (54 existing + 8 new)